### PR TITLE
Add build.sh commands, including installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
     env             # Install building environment
 
+    help            # Show this help
+
     info            # Show information about directories and source versions
 
     version         # Show the script's version

--- a/README.md
+++ b/README.md
@@ -1,59 +1,76 @@
-# Script to build the MS WSL2-modified Linux kernel with ZFS support
+# MS WSL2-modified Linux kernel with ZFS support
 
-Get the WSL2-modified Linux kernel and OpenZFS source code:
-```bash
-git submodule update --init --recursive --progress
-```
-Should already be set to the correct tags. Verify and checkout fitting versions if necessary!
+## Script to build the kernel from source
 
-```bash
-/bin/bash build.sh
-```
+1.  For a fresh install, get the code:
+    ```bash
+    git clone https://github.com/multiheaded/zfs_on_wsl2.git
+    ```
+    If you already have the repo, just run `git pull` to get any updates.\
+    <br/>
 
-Kernel will be `3rdparty/WSL2-Linux-Kernel/arch/x86/boot/bzImage`  
-.deb files are created as `3rdparty/zfs/*.deb`
+2.  Get the WSL2-modified Linux kernel and OpenZFS source code:
+    ```bash
+    git submodule update --init --recursive --progress
+    ```
+    Should already be set to the correct tags. Verify and checkout fitting versions if necessary! \
+    <br/>
 
-Install your newly built kernel by copying it to Windows:
-```
-# Create a directory on "Windows" path to store the kernel
-mkdir -p /mnt/c/wsl2_zfs
+3.  Start the build:
+    ```bash
+    /bin/bash build.sh
+    ```
+    
+    Kernel will be `3rdparty/WSL2-Linux-Kernel/arch/x86/boot/bzImage`  
+    `.deb` files are created as `3rdparty/zfs/*.deb`
 
-# Copy the Kernel file
-cp 3rdparty/WSL2-Linux-Kernel/arch/x86/boot/bzImage /mnt/c/wsl2_zfs/kernel
-```
 
-Also install the comand line utilites:
-```
-sudo dpkg -i 3rdparty/zfs/zfs_*_amd64.deb 3rdparty/zfs/lib*.deb
-```
+## Install the kernel to WSL
 
-In your Windows 10 environment, create or edit %userprofile%/.wslconfig and have it point to your kernel file. Copy and rename if necessary.
-```
-[wsl2]
-kernel=c:\\wsl2_zfs\\kernel
-localhostForwarding=true
-swap=0
-```
+1.  Install your newly built kernel by copying it to Windows:
+    ```bash
+    # Create a directory on "Windows" path to store the kernel
+    mkdir -p /mnt/c/wsl2_zfs
+    
+    # Copy the Kernel file
+    cp 3rdparty/WSL2-Linux-Kernel/arch/x86/boot/bzImage /mnt/c/wsl2_zfs/kernel
+    ```
 
-Start a PowerShell with administrator privileges, stop your WSL instances and restart LxssManager
-```
-wsl --shutdown
-Restart-Service LxssManager
-```
+2.  Also install the command-line utilities:
+    ```bash
+    sudo dpkg -i 3rdparty/zfs/zfs_*_amd64.deb 3rdparty/zfs/lib*.deb
+    ```
 
-In your WSL2 environment, you should now be able to run 
-```bash
-sudo zfs version
-```
-and get appropriate version information about ZFS.
+3.  In your Windows 10 environment, create or edit `%userprofile%/.wslconfig` and have it point to your kernel file. Copy and rename if necessary.
+    ```ini
+    [wsl2]
+    kernel=c:\\wsl2_zfs\\kernel
+    localhostForwarding=true
+    swap=0
+    ```
+
+4.  Start a PowerShell with administrator privileges, stop your WSL instances and restart LxssManager
+    ```batch
+    wsl --shutdown
+    Restart-Service LxssManager
+    ```
+
+5.  In your WSL2 environment, you should now be able to run
+    ```bash
+    sudo zfs version
+    ```
+    and get appropriate version information about ZFS.
+
+
+## Attach your drive with the ZFS partition to your WSL2 VM
 
 To actually use it, check your drive paths from Powershell
-```
+```batch
 wmic diskdrive list brief
 ```
-and mount (bare) to your distribution (e.g. Ubuntu or whatever, but that's optional)
+and mount (bare) to WSL
 ```
-wsl --mount \\.\PHYSICALDRIVE1 --bare [-d Ubuntu-20.04]
+wsl --mount \\.\PHYSICALDRIVE1 --bare
 ```
 
 You can see that drive in Linux
@@ -61,7 +78,9 @@ You can see that drive in Linux
 lsblk
 ```
 
-### Resources:
+and `zfs import {pool}` or create a new pool from scratch.
+
+## Resources:
 - https://wsl.dev/wsl2-kernel-zfs/
 - https://docs.microsoft.com/de-de/windows/wsl/wsl2-mount-disk
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### Syntax
 
 ```bash
-./build.sh [ command ]
+./build.sh [ command [ arguments ] ]
 ```
 
 
@@ -17,6 +17,24 @@
     clean           # Clean up source code
 
     build           # Build kernel from source
+
+    install [ {KERNEL_TARGET_DIR} [ {KERNEL_SUFFIX} ] ]
+                    #
+                    # Install kernel to WSL2
+                    #
+                    # Optional arguments:
+                    #
+                    # - KERNEL_TARGET_DIR indicates the directory where the Kernel is stored on Windows
+                    #
+                    #       Default:  "C:\wsl2_zfs"
+                    #       Note:     Can be given as a Windows path, or WSL path.
+                    #
+                    # - KERNEL_SUFFIX specifies a suffix to be added to the resulting kernel-name:
+                    #       e.g. "kernel-5.15.90.1_zfs-2.1.9-1_SUFFIX.bin".
+                    #
+                    #       Default:  no suffix.
+                    #       Note:     This parameter requires KERNEL_TARGET_DIR to be set.
+                    #                 However, you can use "" if you still want to use the default value.
 
     debs            # Install zfs command-line binaries to current distro
 
@@ -65,6 +83,24 @@
 
 
 ## Install the kernel to WSL
+
+### Option A: Automated install
+
+1. Install the kernel and update `.wslconf`
+    ```bash
+    /bin/bash install
+    ```
+   **Note:** For more installation options, see the syntax of the `install` command above or in the `./build.sh help` command output. \
+   <br/>
+
+2.  Install the zfs command-line utilities
+    ```bash
+    /bin/bash debs
+    ```
+    **Warning:** The installation of these binaries might fail due to missing dependencies or unresolved conflicts. \
+    **Note:** It is also possible to use the zfs binaries supplied by the package maintainers of your distribution.
+
+### Option B: Manual install
 
 1.  Install your newly built kernel by copying it to Windows:
     ```bash

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
     build           # Build kernel from source
 
+    debs            # Install zfs command-line binaries to current distro
+
     env             # Install building environment
 
     help            # Show this help

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ### Commands
 
+    clean           # Clean up source code
+
     build           # Build kernel from source
 
     env             # Install building environment
@@ -38,7 +40,14 @@
     Should already be set to the correct tags. Verify and checkout fitting versions if necessary! \
     <br/>
 
-3.  Start the build:
+3.  In case you had built the kernel before, first clean the source tree:
+    ```bash
+    /bin/bash build.sh clean
+    ```
+    **WARNING:** this will reset any changes you made under the `3rdparty/WSL2-Linux-Kernel` and `3rdparty/zfs` directories! \
+    <br/>
+
+4.  Start the build:
     ```bash
     /bin/bash build.sh
     ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,29 @@
 
 ## Script to build the kernel from source
 
+
+### Syntax
+
+```bash
+./build.sh [ command ]
+```
+
+
+### Commands
+
+    build           # Build kernel from source
+
+    env             # Install building environment
+
+    info            # Show information about directories and source versions
+
+    version         # Show the script's version
+
+## Step-by-step instructions to build the kernel
+
 1.  For a fresh install, get the code:
     ```bash
-    git clone https://github.com/multiheaded/zfs_on_wsl2.git
+    git clone https://github.com/multiheaded/zfs_on_wsl2.git && cd zfs_on_wsl2
     ```
     If you already have the repo, just run `git pull` to get any updates.\
     <br/>
@@ -20,9 +40,10 @@
     ```bash
     /bin/bash build.sh
     ```
-    
-    Kernel will be `3rdparty/WSL2-Linux-Kernel/arch/x86/boot/bzImage`  
-    `.deb` files are created as `3rdparty/zfs/*.deb`
+
+### Result
+- Kernel will be `3rdparty/WSL2-Linux-Kernel/arch/x86/boot/bzImage`
+- `.deb` files are created as `3rdparty/zfs/*.deb`
 
 
 ## Install the kernel to WSL

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ### Commands
 
+    update          # Update source code
+
     clean           # Clean up source code
 
     build           # Build kernel from source
@@ -33,11 +35,12 @@
     If you already have the repo, just run `git pull` to get any updates.\
     <br/>
 
-2.  Get the WSL2-modified Linux kernel and OpenZFS source code:
+2.  Get/update the WSL2-modified Linux kernel and OpenZFS source code:
     ```bash
-    git submodule update --init --recursive --progress
+    /bin/bash build.sh update
     ```
-    Should already be set to the correct tags. Verify and checkout fitting versions if necessary! \
+    **Note:** Should already set the `WSL2-Linux-Kernel` and `zfs` submodules under the `3rdparty` directory to the correct tags.
+    Verify and checkout fitting versions if necessary! \
     <br/>
 
 3.  In case you had built the kernel before, first clean the source tree:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
     debs            # Install zfs command-line binaries to current distro
 
+    wslu            # Install/upgrade WSL Utilities command-line binaries to current distro
+
     env             # Install building environment
 
     help            # Show this help

--- a/build.sh
+++ b/build.sh
@@ -10,24 +10,32 @@ ZFS_SOURCE_DIR=${SUBMODULE_PATH}/zfs
 
 PARALLEL_THREADS=$(/usr/bin/nproc --all)
 
-echo "Script location: "
+echo ""
+echo "Script location:"
 echo $SCRIPT_DIR
 
+echo ""
 echo "WSL2 Kernel source location:"
 echo $WSL_KERNEL_SOURCE_DIR
 
+echo ""
 echo "OpenZFS source location:"
 echo $ZFS_SOURCE_DIR
+echo ""
 
 
 
 function install_build_env {
-	echo "Setting up build environment"
+	echo ""
+	echo "Setting up build environment:"
+	echo ""
 	sudo apt install -yqq build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev python3 python3-dev python3-setuptools python3-cffi libffi-dev flex bison bc dwarves
 }
 
 function prepare_kernel {
-	echo "Preparing kernel"
+	echo ""
+	echo "Preparing kernel:"
+	echo ""
 	cd $WSL_KERNEL_SOURCE_DIR
 
 	# some hardeing options in the Linux kernel are not yet preconfigured in the WSL kernel config, so we do it ourselves...
@@ -39,7 +47,9 @@ function prepare_kernel {
 }
 
 function prepare_zfs {
-	echo "Configuring ZFS source"
+	echo ""
+	echo "Configuring ZFS source:"
+	echo ""
 	cd $ZFS_SOURCE_DIR
 	# https://github.com/openzfs/zfs/commit/b72efb751147ab57afd1588a15910f547cb22600
 	# configure broken on Python version check if not cherry-picked. Probably not necessary in future release
@@ -49,32 +59,42 @@ function prepare_zfs {
 }
 
 function copy_zfs_builtin {
-	echo "Copying ZFS module to kernel source"
+	echo ""
+	echo "Copying ZFS module to kernel source:"
+	echo ""
 	cd $ZFS_SOURCE_DIR
 	./copy-builtin $WSL_KERNEL_SOURCE_DIR
 }
 
 function build_zfs {
-	echo "Building ZFS"
+	echo ""
+	echo "Building ZFS:"
+	echo ""
 	cd $ZFS_SOURCE_DIR
 	make -j${PARALLEL_THREADS}
 	make deb-utils
 }
 
 function enable_zfs_in_kernel {
-	echo "Enabling ZFS in kernel config"
+	echo ""
+	echo "Enabling ZFS in kernel config:"
+	echo ""
 	cd $WSL_KERNEL_SOURCE_DIR
 	echo "CONFIG_ZFS=y" >> .config
 }
 
 function build_zfs_enabled_kernel {
-	echo "Building new WSL2 kernel"
+	echo ""
+	echo "Building new WSL2 kernel:"
+	echo ""
 	cd $WSL_KERNEL_SOURCE_DIR
 	make -j${PARALLEL_THREADS}
 }
 
 function install_kernel_modules {
-	echo "Install modules and metadata to /usr/lib"
+	echo ""
+	echo "Install modules and metadata to /usr/lib:"
+	echo ""
 	cd $WSL_KERNEL_SOURCE_DIR
 	sudo make modules_install
 }

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,8 @@ function install_build_env {
 	echo ""
 	echo "Setting up build environment:"
 	echo ""
-	sudo apt install -yqq build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev python3 python3-dev python3-setuptools python3-cffi libffi-dev flex bison bc dwarves
+	sudo apt install -yqq build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev python3 python3-dev python3-setuptools python3-cffi python3-pip libffi-dev flex bison bc dwarves
+	pip install distlib packaging
 }
 
 function prepare_kernel {

--- a/build.sh
+++ b/build.sh
@@ -133,6 +133,19 @@ function make_all {
 	install_kernel_modules
 }
 
+function make_clean {
+	echo ""
+	echo "Cleaning source:"
+	echo ""
+	cd "$WSL_KERNEL_SOURCE_DIR"
+	git reset --hard
+	git clean -fdx
+	make clean
+	cd "$ZFS_SOURCE_DIR"
+	git reset --hard
+	git clean -fdx
+}
+
 function version_kernel {
 	if [ -r 3rdparty/WSL2-Linux-Kernel/.config ]; then
 		grep "Kernel Configuration" 3rdparty/WSL2-Linux-Kernel/.config | cut -d" " -f3
@@ -163,6 +176,8 @@ SYNTAX:
 
 COMMANDS:
 
+    clean           # Clean up source code
+
     build           # Build kernel from source
 
     env             # Install building environment
@@ -184,6 +199,12 @@ if (( $# == 0 )); then
 else
 	while (( $# > 0 )); do
 	case "$1" in
+
+	clean)
+	  print_info
+		shift
+		make_clean
+		;;
 
 	build|"")
 		print_info

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Fail on errors, undefined variables, or command piping errors
+set -euo pipefail
+
 SCRIPT_VERSION=1.1.0
 SCRIPT_PATH=$(readlink -f $0)
 SCRIPT_DIR=$(dirname $SCRIPT_PATH)

--- a/build.sh
+++ b/build.sh
@@ -122,6 +122,15 @@ function install_kernel_modules {
 	sudo make modules_install
 }
 
+function install_debs {
+	echo ""
+	echo "Installing command line tools:"
+	echo ""
+
+	cd "$SCRIPT_DIR"
+	sudo apt install 3rdparty/zfs/zfs_*_amd64.deb 3rdparty/zfs/lib*.deb libzfs4linux
+}
+
 function make_all {
 	install_build_env
 	prepare_kernel
@@ -182,6 +191,8 @@ COMMANDS:
 
     build           # Build kernel from source
 
+    debs            # Install zfs command-line binaries to current distro
+
     env             # Install building environment
 
     help            # Show this help
@@ -212,6 +223,12 @@ else
 		print_info
 		shift
 		make_all
+		;;
+
+	debs)
+		print_info
+		shift
+		install_debs
 		;;
 
 	env)

--- a/build.sh
+++ b/build.sh
@@ -131,6 +131,18 @@ function install_debs {
 	sudo apt install 3rdparty/zfs/zfs_*_amd64.deb 3rdparty/zfs/lib*.deb libzfs4linux
 }
 
+function install_wslu {
+	echo ""
+	echo "Installing latest WSL Utilities:"
+	echo ""
+	add-apt-repository -L | grep -q wslutilities/wslu
+	if (( $? != 0 )); then
+		sudo add-apt-repository -y ppa:wslutilities/wslu
+		sudo apt update
+	fi
+	sudo apt upgrade wslu
+}
+
 function make_all {
 	install_build_env
 	prepare_kernel
@@ -193,6 +205,8 @@ COMMANDS:
 
     debs            # Install zfs command-line binaries to current distro
 
+    wslu            # Install/upgrade WSL Utilities command-line binaries to current distro
+
     env             # Install building environment
 
     help            # Show this help
@@ -247,6 +261,11 @@ else
 		shift
 		git pull
 		git submodule update --init --recursive --progress
+		;;
+
+	wslu)
+		shift
+		install_wslu
 		;;
 
 	-h|--help|help)

--- a/build.sh
+++ b/build.sh
@@ -151,6 +151,34 @@ function version_zfs {
 	fi
 }
 
+function print_help {
+  cat << EOT
+
+$(print_version)
+
+SYNTAX:
+
+    ./build.sh [ command [arguments] ]
+
+
+COMMANDS:
+
+    build           # Build kernel from source
+
+    env             # Install building environment
+
+    help            # Show this help
+
+    info            # Show information about directories and source versions
+
+    version         # Show the script's version
+
+
+INFO:
+EOT
+}
+
+
 if (( $# == 0 )); then
 	make_all
 else
@@ -167,6 +195,17 @@ else
 		print_info
 		shift
 		install_build_env
+		;;
+
+	info)
+		shift
+		print_info
+		;;
+
+	-h|--help|help)
+		shift
+		print_help
+		print_info
 		;;
 
 	-V|--version|version)

--- a/build.sh
+++ b/build.sh
@@ -176,6 +176,8 @@ SYNTAX:
 
 COMMANDS:
 
+    update          # Update source code
+
     clean           # Clean up source code
 
     build           # Build kernel from source
@@ -221,6 +223,13 @@ else
 	info)
 		shift
 		print_info
+		;;
+
+	update)
+		print_info
+		shift
+		git pull
+		git submodule update --init --recursive --progress
 		;;
 
 	-h|--help|help)


### PR DESCRIPTION
Add the following commands to `build.sh`:

### Syntax

```bash
./build.sh [ command [ arguments ] ]
```


### Commands

    update          # Update source code

    clean           # Clean up source code

    build           # Build kernel from source

    install [ {KERNEL_TARGET_DIR} [ {KERNEL_SUFFIX} ] ]
                    #
                    # Install kernel to WSL2
                    #
                    # Optional arguments:
                    #
                    # - KERNEL_TARGET_DIR indicates the directory where the Kernel is stored on Windows
                    #
                    #       Default:  "C:\wsl2_zfs"
                    #       Note:     Can be given as a Windows path, or WSL path.
                    #
                    # - KERNEL_SUFFIX specifies a suffix to be added to the resulting kernel-name:
                    #       e.g. "kernel-5.15.90.1_zfs-2.1.9-1_SUFFIX.bin".
                    #
                    #       Default:  no suffix.
                    #       Note:     This parameter requires KERNEL_TARGET_DIR to be set.
                    #                 However, you can use "" if you still want to use the default value.

    debs            # Install zfs command-line binaries to current distro

    wslu            # Install/upgrade WSL Utilities command-line binaries to current distro

    env             # Install building environment

    help            # Show this help

    info            # Show information about directories and source versions

    version         # Show the script's version


See updated README.md for futher details.